### PR TITLE
Improve visually the pti-docs portal & update the CSS colors to the new Fiant palette in the portal & documentation

### DIFF
--- a/api/v1/pti-doc-styles.css
+++ b/api/v1/pti-doc-styles.css
@@ -1,18 +1,20 @@
 :root {
     /* Common colors */
-    --get-color: 36, 104, 239;
-    --post-color: 0, 189, 171;
-    --put-color: 0, 140, 200;
-    --patch-color: 136, 36, 224;
-    --delete-color: 330, 45, 92;
+    --get-color: 46, 107, 229;
+    --post-color: 20, 215, 177;
+    --put-color: 25, 150, 180;
+    --patch-color: 153, 79, 217;
+    --delete-color: 240, 60, 83;
 
     /* Dark Theme colors */
-    --bg-color: 16, 16, 52;
-    --required-color: orangered;
+    --bg-color: 38, 42, 42;
     --text-color: 255, 255, 255;
+    --required-color: orangered;
     --alt-text-color: lightgray;
 
     /* Light Theme colors */
+    --bg-color-light: 230, 242, 240;
+    --text-color-light: 30, 30, 30;
     --required-color-light: 255, 0, 0;
     --alt-text-color-light: 59, 65, 81;
 }
@@ -200,13 +202,12 @@ body {
 
 @media (prefers-color-scheme: light) {
     html {
-        /* Inherit default background for light theme */
-        background-color: inherit;
+        background-color: rgb(var(--bg-color-light));
     }
+
     .swagger-ui {
         background-color: inherit;
 
-        /* Inherit default text color for light theme */
         .info p,
         .info .main h2,
         .opblock .opblock-section-header h4,
@@ -239,7 +240,7 @@ body {
         .parameters-col_name .parameter__in,
         .response-control-media-type__accept-message,
         .prop .property.primitive {
-            color: inherit;
+            color: rgb(var(--text-color-light));
         }
 
         .markdown code, .renderedMarkdown code {
@@ -271,7 +272,7 @@ body {
 
         /* Background color for light mode on section headers */
         .opblock .opblock-section-header {
-            background-color: inherit;
+            background-color: rgb(var(--bg-color-light));
         }
 
         /* GET method light theme color */

--- a/index.html
+++ b/index.html
@@ -1,20 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>PTI Docs</title>
-    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/style.min.css" title="docsify-darklight-theme" type="text/css" />
-</head>
-<body>
-<p>
-    <a href="api/v1/index.html">API reference</a>
-</p>
-<p>
-    <a href="api-dev/v1/index.html">DEV API reference</a>
-</p>
-<p>
-    <a href="guide/v1/index.html">Developer's guide</a>
-</p>
-
-</body>
+    <head>
+        <meta charset="UTF-8">
+        <title>PTI Docs</title>
+        <link rel="stylesheet" href="styles.css" type="text/css" />
+    </head>
+    <body>
+        <div id="title">
+            <img src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNjAiIGhlaWdodD0iMjYwIiB2aWV3Qm94PSIwIDAgMjYwIDI2MCIgZmlsbD0ibm9uZSI+CiAgPHBhdGggZD0iTTcwIDg4LjAwMDdMMTI1LjM5NyA1OS44NlYxMEg4Ni44NTc0Qzc3LjU1MDggMTAgNzAgMTcuNTUwOCA3MCAyNi44NTc0Vjg4LjAwMDdaIiBmaWxsPSIjMjJFOUJFIj48L3BhdGg+CiAgPHBhdGggZD0iTTEzNS4xMDUgMTBWNTQuOTk4TDE5MC41MDMgMjYuODU3NEMxOTAuNTAzIDE3LjU1MDggMTgyLjk1MiAxMCAxNzMuNjQ1IDEwTDEzNS4xMDUgMTBaIiBmaWxsPSIjMjJFOUJFIj48L3BhdGg+CiAgPHBhdGggZD0iTTEzNS4xMDUgMjUwLjY3VjIwNy4yMTlMMTkwLjUwMyAxNzkuMDc4VjIzMy44MjVDMTkwLjUwMyAyNDMuMTMxIDE4Mi45NTIgMjUwLjY4MiAxNzMuNjQ1IDI1MC42ODJIMTM1LjEwNVYyNTAuNjdaIiBmaWxsPSIjMjJFOUJFIj48L3BhdGg+CiAgPHBhdGggZD0iTTcwIDE1OC41MDJMMTkwLjUxOSA5Ny4yNzI5VjM4LjEzMDlMNzAgOTkuMzYwMVYxNTguNTAyWiIgZmlsbD0iIzIyRTlCRSI+PC9wYXRoPgogIDxwYXRoIGQ9Ik0xOTAuNTE5IDEwOC41MTJMNzAgMTY5Ljc0MVYyMzMuODE5QzcwIDI0My4xMjUgNzcuNTUwOCAyNTAuNjc2IDg2Ljg1NzQgMjUwLjY3NkgxMjUuMzk3VjIwMC43NDJMMTkwLjUxOSAxNjcuNjU0VjEwOC41MTJaIiBmaWxsPSIjMjJFOUJFIj48L3BhdGg+Cjwvc3ZnPgo="  alt="Fiant logo"/>
+            <h1>Provenance technologies institutional API</h1>
+        </div>
+        <div class="button-container">
+            <p><a href="api/v1/index.html" class="button">API reference</a></p>
+            <p><a href="api-dev/v1/index.html" class="button">DEV API reference</a></p>
+            <p><a href="guide/v1/index.html" class="button">Developer's guide</a></p>
+        </div>
+    </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,92 @@
+:root {
+    --button-color: 0, 235, 190;
+    --button-text-color: 30, 30, 30;
+
+    /* Dark Theme colors */
+    --bg-color: 38, 42, 42;
+    --text-color: 255, 255, 255;
+    --alt-text-color: lightgray;
+
+    /* Light Theme colors */
+    --bg-color-light: 230, 242, 240;
+    --text-color-light: 30, 30, 30;
+    --alt-text-color-light: 59, 65, 81;
+}
+
+*,
+*:before,
+*:after {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: Jost, sans-serif;
+}
+
+html, body {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    transition: background-color 0.3s, color 0.3s;
+    /* Dark background by default */
+    background-color: rgb(var(--bg-color));
+    color: rgb(var(--text-color));
+}
+
+h1 {
+    font-size: 2.25rem;
+}
+
+a {
+    text-decoration: none;
+}
+
+#title {
+    align-items: center;
+    display: flex;
+    gap: 16px;
+    justify-content: center;
+    margin-top: 50px;
+}
+
+#title img {
+    width: 2.25rem;
+}
+
+.button-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    flex-grow: 1;
+}
+
+.button {
+    background-color: rgb(var(--button-color));
+    color: rgb(var(--button-text-color));
+    display: block;
+    width: 300px;
+    padding: 15px 0;
+    margin: 10px 0;
+    font-size: 1.2rem;
+    text-align: center;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background-color 0.3s, transform 0.2s;
+}
+
+.button:hover {
+    transform: scale(1.05);
+}
+
+.button:active {
+    transform: scale(1);
+}
+
+@media (prefers-color-scheme: light) {
+    html, body {
+        background-color: rgb(var(--bg-color-light));
+        color: rgb(var(--text-color-light));
+    }
+}


### PR DESCRIPTION
- Add some CSS to the pti-docs portal.
- Adjust the CSS colors to the new Fiant palette in the portal & documentation.


Portal dark mode (default):
![Screenshot 2024-10-25 at 11 54 25 AM](https://github.com/user-attachments/assets/1afdc0eb-e741-435e-8f79-a269ec5e40da)

Portal light mode:
![Screenshot 2024-10-25 at 11 54 42 AM](https://github.com/user-attachments/assets/4111853c-db1c-4279-b6df-613727072c0b)

Updated documentation colors:
![Screenshot 2024-10-25 at 11 55 05 AM](https://github.com/user-attachments/assets/aeeff234-d965-4076-a65a-f37454a93da7)
